### PR TITLE
TASK: always wrap div

### DIFF
--- a/Classes/Fusion/FormElementWrappingImplementation.php
+++ b/Classes/Fusion/FormElementWrappingImplementation.php
@@ -108,7 +108,7 @@ class FormElementWrappingImplementation extends AbstractFusionObject
         if ($node->getNodeType()->isOfType('Neos.Neos:ContentCollection') && count($node->getChildNodes()) === 0) {
             $additionalAttributes['data-_neos-form-builder-empty-collection'] = true;
         }
-        return $this->contentElementWrappingService->wrapContentObject($node, $output, $fusionPath, $additionalAttributes);
+        return $this->contentElementWrappingService->wrapContentObject($node,'<div>'.$output.'</div>', $fusionPath, $additionalAttributes);
     }
 
 }


### PR DESCRIPTION
There is no interface for forcing new tags when using the HtmlAugmenter (implicitely called via wrapContentObject) so this quick change solves the problem of divs not getting nested as described in issue #139.